### PR TITLE
Add support for sanctuary-type-identifiers 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,7 @@
     Concurrently.prototype =
     construct.prototype = {constructor: construct};
 
+    proto[$$type] = OUTERTYPE;
     construct[$$type] = OUTERTYPE;
 
     var mzero = new Concurrently (zero);


### PR DESCRIPTION
An alternative to the direction #35 is taking.

This approach simply adds the `@@type` property to the prototype, on top of it staying on the constructor. This way, `sanctuary-type-identifiers@3` can understand the type of these instances, whilst the code that relies on `sanctuary-type-identifiers@2` is kept intact.

The benefit of this approach is that I can keep doing tricks like generating a type identifier from the type identity of another type representative. The drawback is that as other libraries switch to specifying their type identities according to `sanctuary-type-identifiers@3`, this library will lose the knowledge about those types.

Closes #35

/cc @davidchambers 